### PR TITLE
chore: remove unused n2k-signalk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "bluebird": "^3.0.0",
     "debug": "^3.1.0",
     "ggencoder": "^1.0.2",
-    "n2k-signalk": "^0.0.3",
     "superagent": "^3.3.2",
     "superagent-promise": "^1.0.3"
   },


### PR DESCRIPTION
n2k-signalk is not used and is anyway superceded by @signalk/n2k-signalk.